### PR TITLE
Updated soon to be removed Arduino pin names

### DIFF
--- a/base/creality-cr10spro.cfg
+++ b/base/creality-cr10spro.cfg
@@ -2,13 +2,13 @@
 # this config, the firmware should be compiled for the AVR atmega2560.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_min: 0
 position_max: 300
@@ -16,13 +16,13 @@ homing_speed: 50
 homing_retract_dist: 5
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_min: 0
 position_max: 310
@@ -30,9 +30,9 @@ homing_speed: 50
 homing_retract_dist: 5
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 rotation_distance: 8
 microsteps: 16
 full_steps_per_rotation: 200
@@ -41,9 +41,9 @@ position_min: -1
 position_max: 351
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 rotation_distance: 22.900
 microsteps: 16
 full_steps_per_rotation: 200
@@ -52,9 +52,9 @@ filament_diameter: 1.750
 max_extrude_only_distance: 500.0
 max_extrude_only_velocity: 70.0
 max_extrude_only_accel: 1000.0
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -64,9 +64,9 @@ min_temp: 5
 max_temp: 275
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
@@ -75,11 +75,10 @@ min_temp: 5
 max_temp: 140
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06VNAB-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -89,7 +88,7 @@ max_z_velocity: 10
 max_z_accel: 100
 
 [probe]
-pin: ar18
+pin: PD3
 x_offset: -27
 y_offset: 0
 z_offset: 0
@@ -113,7 +112,7 @@ fade_start: 1
 fade_end: 10
 
 [filament_switch_sensor e0_sensor]
-switch_pin: ar2
+switch_pin: PE4
 pause_on_runout: False
 runout_gcode:
   PAUSE_PARK

--- a/base/creality-cr10sprov2.cfg
+++ b/base/creality-cr10sprov2.cfg
@@ -2,13 +2,13 @@
 # this config, the firmware should be compiled for the AVR atmega2560.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 0
 position_min: 0
 position_max: 300
@@ -16,13 +16,13 @@ homing_speed: 50
 homing_retract_dist: 5
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 0
 position_min: 0
 position_max: 310
@@ -30,9 +30,9 @@ homing_speed: 50
 homing_retract_dist: 5
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 rotation_distance: 8
 microsteps: 16
 full_steps_per_rotation: 200
@@ -41,9 +41,9 @@ position_min: -1
 position_max: 351
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 rotation_distance: 22.900
 microsteps: 16
 full_steps_per_rotation: 200
@@ -52,9 +52,9 @@ filament_diameter: 1.750
 max_extrude_only_distance: 500.0
 max_extrude_only_velocity: 70.0
 max_extrude_only_accel: 1000.0
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -64,9 +64,9 @@ min_temp: 5
 max_temp: 275
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
@@ -75,11 +75,10 @@ min_temp: 5
 max_temp: 140
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06VNAB-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -89,8 +88,8 @@ max_z_velocity: 10
 max_z_accel: 100
 
 [bltouch]
-sensor_pin: ^ar19
-control_pin: ar11
+sensor_pin: ^PD2
+control_pin: PB5
 stow_on_each_sample: False
 probe_with_touch_mode: True
 x_offset: -27
@@ -116,7 +115,7 @@ fade_start: 1
 fade_end: 10
 
 [filament_switch_sensor e0_sensor]
-switch_pin: ar2
+switch_pin: PE4
 pause_on_runout: False
 runout_gcode:
   PAUSE_PARK

--- a/base/creality-ender5plus.cfg
+++ b/base/creality-ender5plus.cfg
@@ -2,13 +2,13 @@
 # this config, the firmware should be compiled for the AVR atmega2560.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: 360
 position_min: 0
 position_max: 360
@@ -16,13 +16,13 @@ homing_speed: 50
 homing_retract_dist: 5
 
 [stepper_y]
-step_pin: ar60
-dir_pin: ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: PF7
+enable_pin: !PF2
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: 360
 position_min: 0
 position_max: 360
@@ -30,9 +30,9 @@ homing_speed: 50
 homing_retract_dist: 5
 
 [stepper_z]
-step_pin: ar46
-dir_pin: ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: PL1
+enable_pin: !PK0
 rotation_distance: 4
 microsteps: 16
 full_steps_per_rotation: 200
@@ -41,9 +41,9 @@ position_min: -1
 position_max: 411
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 rotation_distance: 34.400
 microsteps: 16
 full_steps_per_rotation: 200
@@ -52,9 +52,9 @@ filament_diameter: 1.750
 max_extrude_only_distance: 750.0
 max_extrude_only_velocity: 75.0
 max_extrude_only_accel: 1000.0
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp: 22.2
 pid_Ki: 1.08
@@ -64,9 +64,9 @@ min_temp: 5
 max_temp: 275
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp: 690.34
 pid_Ki: 111.47
@@ -75,11 +75,10 @@ min_temp: 5
 max_temp: 140
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06VNAB-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -89,8 +88,8 @@ max_z_velocity: 10
 max_z_accel: 100
 
 [bltouch]
-sensor_pin: ^ar18
-control_pin: ar11
+sensor_pin: ^PD3
+control_pin: PB5
 stow_on_each_sample: False
 probe_with_touch_mode: True
 x_offset: -41
@@ -116,7 +115,7 @@ fade_start: 1
 fade_end: 10
 
 [filament_switch_sensor e0_sensor]
-switch_pin: ar2
+switch_pin: PE4
 pause_on_runout: False
 runout_gcode:
   PAUSE_PARK

--- a/contrib/creality-cr10spro-rext3d.cfg
+++ b/contrib/creality-cr10spro-rext3d.cfg
@@ -4,13 +4,13 @@
 # Modified by ReXT3D.
 
 [stepper_x]
-step_pin: ar54
-dir_pin: ar55
-enable_pin: !ar38
+step_pin: PF0
+dir_pin: PF1
+enable_pin: !PD7
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar3
+endstop_pin: ^PE5
 position_endstop: -1.0                  # start the 300mm print surface at 5mm inset from 310mm X-sized bed edge
 position_min: -1.0
 position_max: 316                       # approximately 3mm margin to physical X-movement range of 320mm
@@ -20,13 +20,13 @@ homing_retract_dist: 5
 second_homing_speed: 10                 # reduced to get better accuracy (not critical)
 
 [stepper_y]
-step_pin: ar60
-dir_pin: !ar61
-enable_pin: !ar56
+step_pin: PF6
+dir_pin: !PF7
+enable_pin: !PF2
 rotation_distance: 40
 microsteps: 16
 full_steps_per_rotation: 200
-endstop_pin: ^ar14
+endstop_pin: ^PJ1
 position_endstop: -7.0                  # start the 300mm print surface at 10mm inset from 320mm Y-sized bed edge (requires correct Y-stop mechanical position adjustment)
 position_min: -7.0
 position_max: 306                       # approximately 2mm margin to physical Y-movement limit of 315mm (requires correct Y-stop mechanical position adjustment)
@@ -36,9 +36,9 @@ homing_retract_dist: 5
 second_homing_speed: 10                 # reduced to get better accuracy (not critical)
 
 [stepper_z]
-step_pin: ar46
-dir_pin: !ar48
-enable_pin: !ar62
+step_pin: PL3
+dir_pin: !PL1
+enable_pin: !PK0
 rotation_distance: 8
 microsteps: 16
 full_steps_per_rotation: 200
@@ -51,9 +51,9 @@ homing_retract_dist: 1.6                # this is conservative: we need less, ju
 second_homing_speed: 0.2                # very slow approach speeds are a MUST, even with a high quality capacitive probe; more so with OEM probe
 
 [extruder]
-step_pin: ar26
-dir_pin: ar28
-enable_pin: !ar24
+step_pin: PA4
+dir_pin: PA6
+enable_pin: !PA2
 rotation_distance: 22.857               # this is factory configuration of 140 steps/mm that underextrudes (98 mm instead of 100 mm)
 microsteps: 16
 full_steps_per_rotation: 200
@@ -62,9 +62,9 @@ filament_diameter: 1.750
 max_extrude_only_distance: 500.0
 max_extrude_only_velocity: 70.0
 max_extrude_only_accel: 1000.0
-heater_pin: ar10
+heater_pin: PB4
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog13
+sensor_pin: PK5
 control: pid
 pid_Kp = 28.213                         # stock Creality hot end with ReXT3D cooling duct @ 50% flow
 pid_Ki = 1.774                          # stock Creality hot end with ReXT3D cooling duct @ 50% flow
@@ -74,9 +74,9 @@ min_temp: 5
 max_temp: 275
 
 [heater_bed]
-heater_pin: ar8
+heater_pin: PH5
 sensor_type: EPCOS 100K B57560G104F
-sensor_pin: analog14
+sensor_pin: PK6
 control: pid
 pid_Kp = 74.305                         # Creality borosilicate glass bed
 pid_Ki = 1.242                          # Creality borosilicate glass bed
@@ -85,11 +85,10 @@ min_temp: 5
 max_temp: 140
 
 [fan]
-pin: ar9
+pin: PH6
 
 [mcu]
 serial: /dev/serial/by-id/usb-FTDI_FT232R_USB_UART_AK06VNAB-if00-port0
-pin_map: arduino
 
 [printer]
 kinematics: cartesian
@@ -104,7 +103,7 @@ shaper_freq_y: 34.0                     # stock CR-10S Pro with very well assemb
 shaper_type: mzv
 
 [probe]
-pin: ar18
+pin: PD3
 x_offset: -28                           # as measured on the printer, the offset is actually 28mm
 y_offset: 0
 z_offset: 0                             # this needs to be adjusted for each printer to achieve correct first layer height
@@ -139,7 +138,7 @@ speed: 80
 probe_speed: 3.2                        # can approach faster than bed mesh probing for a coarse manual screw adjustment
 
 [filament_switch_sensor e0_sensor]
-switch_pin: ar2
+switch_pin: PE4
 pause_on_runout: False
 runout_gcode:
   M600


### PR DESCRIPTION
An upcoming Klipper release will remove the deprecated `pin_map: arduino` and it's Arduino pin names from Klipper - see https://github.com/Klipper3d/klipper/pull/4834.

This PR updates the Arduino pin names in all .cfg files with the "MCU pin names" defined here: https://github.com/Klipper3d/klipper/blob/master/config/sample-aliases.cfg